### PR TITLE
Adding support for detecting Chrome on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,28 @@ Here is the list of props used by the component.
 |children   |Object { browserName: function(browserName){ return node; }  }    |    |An object containing functions to handle different browsers. Properties would be called like browsers: ```chrome```, ```firefox```, ```ie```, ```edge```, ```safari```, ```opera```, ```blink```, ```googlebot``` and ```default```. If specified, the component will use the function under the property with the name of the browser, otherwise, it will use ```default```. Each function take the browser name as parameter and must return a node     |
 
 
+### Determining the OS
+
+At this time, only desktop and Android variations are being detected.  Others may be added as the need arises.
+To determine if the browser is running on Android, prefix its name with `android-` in the object you pass as children.
+You can also use `android` alone to fallback to a general case.
+
+**Example**
+
+```javascript
+const browserHandler = {
+  chrome: () => <div>Chrome is fantastic!</div>,
+  googlebot: () => <div>Hi GoogleBot!</div>,
+  android: () => <div>Whatever browser you have, it must be on Android!</div>
+  'android-chrome': () => <div>Chrome is a good choice for Android!</div>
+  default: (browser) => <div>Hi {browser}!</div>,
+};
+
+```
+
+Handler determination goes from most to least specific.  It will first look for an `android-browserName` match and then `android` (assuming the OS is Android) then failing that it will look for `browserName` and finally will fallback to using `default`.  This allows you to custom tailor responses for each scenario, or to provide general cases.
+
+
 ## Author
 **Matteo Basso**
 - [github/mbasso](https://github.com/mbasso)

--- a/src/index.js
+++ b/src/index.js
@@ -48,18 +48,18 @@ export default class BrowserDetection extends React.Component {
       browser = 'unknown';
     }
 
-    browser = (isAndroid ? 'android-' : '') + browser;
-
     this.state = {
       browser,
+      isAndroid
     };
     this.state.children = this.renderChildren();
   }
 
   renderChildren = () => {
     const { children } = this.props;
-    const { browser } = this.state;
-    const render = children[browser] || children.default || (() => null);
+    const { browser, isAndroid } = this.state;
+    const render = (isAndroid ? (children[`android-${browser}`] || children.android) : null)
+      || children[browser] || children.default || (() => null);
     return render(browser);
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -14,12 +14,15 @@ export default class BrowserDetection extends React.Component {
   constructor(...params) {
     super(...params);
 
+    const isAndroid = navigator.userAgent.toLowerCase().indexOf('android') !== -1;
     const isIE = /*@cc_on!@*/false || !!document.documentMode;
     const isEdge = !(isIE) && !!window.StyleMedia;
     const isFirefox = typeof InstallTrigger !== 'undefined';
     const isOpera = (!!window.opr && !!window.opr.addons) || !!window.opera
                     || navigator.userAgent.indexOf(' OPR/') >= 0;
-    const isChrome = !!window.chrome && !!window.chrome.webstore && navigator.userAgent.toLowerCase().indexOf('googlebot') === -1;
+    const isChrome = !!window.chrome &&
+                    (!!window.chrome.webstore || isAndroid) &&
+                    navigator.userAgent.toLowerCase().indexOf('googlebot') === -1;
     const isSafari = !isChrome && navigator.userAgent.toLowerCase().indexOf('safari') !== -1;
     const isBlink = (isChrome || isOpera) && !!window.CSS;
     const isGoogleBot = navigator.userAgent.toLowerCase().indexOf('googlebot') !== -1;
@@ -44,6 +47,8 @@ export default class BrowserDetection extends React.Component {
     } else {
       browser = 'unknown';
     }
+
+    browser = (isAndroid ? 'android-' : '') + browser;
 
     this.state = {
       browser,


### PR DESCRIPTION
Changes:
- Chrome on Android will not have the 'webstore' attribute.
- Appending 'android-' when applicable to allow for finer grade detection
